### PR TITLE
Make firstPersonArmFeatures protected

### DIFF
--- a/src/main/java/dev/doctor4t/ratatouille/mixin/client/armor/LivingEntityRendererMixin.java
+++ b/src/main/java/dev/doctor4t/ratatouille/mixin/client/armor/LivingEntityRendererMixin.java
@@ -24,7 +24,7 @@ import java.util.List;
 @Mixin(LivingEntityRenderer.class)
 public abstract class LivingEntityRendererMixin<T extends LivingEntity, M extends EntityModel<T>> extends EntityRenderer<T> implements FeatureRendererContext<T, M> {
     @Unique
-    List<FeatureRenderer<T, M>> firstPersonArmFeatures = new ArrayList<>();
+    protected List<FeatureRenderer<T, M>> firstPersonArmFeatures = new ArrayList<>();
 
     protected LivingEntityRendererMixin(EntityRendererFactory.Context ctx) {
         super(ctx);


### PR DESCRIPTION
Fixes #11 

https://github.com/doctor4t/Ratatouille/blob/1222c20ce1b0af626174da6462c0bd31b2ad84ea/src/main/java/dev/doctor4t/ratatouille/mixin/client/armor/LivingEntityRendererMixin.java#L26-L27
https://github.com/doctor4t/Ratatouille/blob/1222c20ce1b0af626174da6462c0bd31b2ad84ea/src/main/java/dev/doctor4t/ratatouille/mixin/client/armor/PlayerEntityRendererMixin.java#L41-L43

This field is package-private, which works during compile time (the mixin classes share the same package). This also works during runtime for yarn (`net.minecraft.client.render.entity.LivingEntityRenderer` and `net.minecraft.client.render.entity.PlayerEntityRenderer`) and intermediary (`net.minecraft.class_922` and `net.minecraft.class_1007`), but fails for mojmap (`net.minecraft.client.renderer.entity.LivingEntityRenderer` and `net.minecraft.client.renderer.entity.player.PlayerRenderer`) because they no longer share the same package.

The current solution is to make the field `protected` instead of `package-private` so `PlayerEntityRenderer` can always access the field.